### PR TITLE
Set daaHeight for Mainnet

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -134,6 +134,7 @@ public class MainNetParams extends AbstractBitcoinNetParams {
         uahfHeight = 478559;
         /** Activation time at which the cash HF kicks in. */
         cashHardForkActivationTime = 1510600000;
+        daaHeight = 504032;
     }
 
     private static MainNetParams instance;


### PR DESCRIPTION
It does not work well with Mainnet, so I set `daaHeight` properly in MainNetParams
Reference: https://www.bitcoinabc.org/november-13-upgrade-update